### PR TITLE
Specify installing all of base

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -11,7 +11,7 @@ RUN    pacman-key --init \
     && pacman --noconfirm -Syw ca-certificates-utils \
     && rm /etc/ssl/certs/ca-certificates.crt \
     && pacman --noconfirm -S ca-certificates-utils \
-    && pacman --noconfirm -Syu \
+    && pacman --noconfirm -Syu base \
     && chmod  755 /etc \
     && chmod  755 /etc/pacman.d \
     && chmod  644 /etc/pacman.d/mirrorlist \


### PR DESCRIPTION
This is specified in the wiki page about arch rootfs

https://wiki.archlinux.org/index.php/Installation_guide#Install_the_base_packages

And you are currently not installing all of base in the base Dockerfile

```
$ docker run -ti --rm base/archlinux pacman -Syi gzip
:: Synchronizing package databases...
 core                                                                                                                                      125.0 KiB   658K/s 00:00 [#####################################################################################################] 100%
 extra                                                                                                                                    1682.1 KiB   472K/s 00:04 [#####################################################################################################] 100%
 community                                                                                                                                   3.8 MiB   529K/s 00:07 [#####################################################################################################] 100%
Repository      : core
Name            : gzip
Version         : 1.8-2
Description     : GNU compression utility
Architecture    : x86_64
URL             : http://www.gnu.org/software/gzip/
Licenses        : GPL3
Groups          : base  base-devel
Provides        : None
Depends On      : glibc  bash  less
Optional Deps   : None
Conflicts With  : None
Replaces        : None
Download Size   : 75.83 KiB
Installed Size  : 146.00 KiB
Packager        : S
Build Date      : Sat May 14 12:51:57 2016
Validated By    : MD5 Sum  SHA-256 Sum  Signature

$ docker run -ti --rm base/archlinux pacman -Q gzip
warning: database file for 'core' does not exist
warning: database file for 'extra' does not exist
warning: database file for 'community' does not exist
error: package 'gzip' was not found
```