### PR TITLE
minify base image

### DIFF
--- a/Dockerfiles/basement/Dockerfile.base
+++ b/Dockerfiles/basement/Dockerfile.base
@@ -18,7 +18,10 @@ RUN : \
          device-mapper \
          dhcpcd \
          iproute2 \
+         iptables \
          jfsutils \
+         libpcap \
+         libusb \
          linux \
          lvm2 \
          man-db \
@@ -32,6 +35,7 @@ RUN : \
          reiserfsprogs \
          s-nail \
          systemd-sysvcompat \
+         systemd \
          usbutils \
          vi \
          xfsprogs \


### PR DESCRIPTION
These packages can get removed safely and save ~20MB (5%) space.