### PR TITLE
Use the latest version of the docker Python library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ services:
   - docker
 install:
   - sudo pip install https://github.com/goldmann/docker-squash/archive/master.zip
-  # Force the 2.x release of docker, as docker-squash is currently incompatible (2018-02-05)
-  - sudo pip install "docker<3.0.0"
   # On 1. day, still use last month's tarfile,
   # the latest one may not be on the mirror yet
   - export TAR_DATE=$(date --date=yesterday +'%Y.%m.01')


### PR DESCRIPTION
Since https://github.com/goldmann/docker-squash/pull/171 was merged, docker-squash now supports docker 3, so it is not longer necessary to use an older version.